### PR TITLE
Fix for randomflip ValueError on randrange call

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,3 +1,4 @@
+import random, math
 def testAll():
     assert (message([1]) == [0, 0, 1, 1])
     assert (message([0, 0, 1]) == [0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 0])
@@ -45,9 +46,11 @@ def testAll():
     assert (repetitionDecoder([1, 1, 1, 1]) == [1])
 
     print('all tests passed')
-    
-import random, math   
+       
 def randomflip(data):
+    #If the encoded data is invalid (empty array), there is nothing to flip
+    if len(data) == 0:
+        return data
     bit = random.randrange(len(data))
     data[bit] = (data[bit]+1)%2
     return data


### PR DESCRIPTION
Function random.randrange can't accept 0 as a length parameter so will raise an Exception when data has length 0 due to original generated input being invalid.